### PR TITLE
Do not declare home directory as a volume mount. 

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -32,7 +32,7 @@ ADD ${DOWNLOAD_URL} /tmp/go-agent.zip
 ADD <%= meta[:url] %> <%= file %>
 <% end %>
 # allow mounting ssh keys, dotfiles, and the go server config and data
-VOLUME /home/go /godata
+VOLUME /godata
 
 # force encoding
 ENV LANG=en_US.utf8


### PR DESCRIPTION
Users should explicitly mount the home directory with -v iption for ssh keys

#16 