### PR TITLE
Log everything to stdout as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Docker GoCD agent 17.9.0
+
+* log agent output and logs to `STDOUT` in addition to writing logs to log files, so you can now watch all agent logs using `docker logs`.
+
 # Docker GoCD agent 17.8.0
 
 * [dc49b6d](https://github.com/gocd/docker-gocd-agent/commit/dc49b6df3856ebf91ae59562e42968ecca942b93) Create slimmer agent images by deleting the downloaded zip after extraction.
@@ -19,4 +23,4 @@ No changes.
 ## Bug Fixes
 
 * [27b8772](https://github.com/gocd/docker-gocd-agent/commit/27b8772) Remove `/home/go` from the volume instruction. This makes the `/home/go` directory writable by `go` user.
-* [44b592f](https://github.com/gocd/docker-gocd-agent/commit/44b592f) Create home directory `/home/go` for docker agent images based on debian. 
+* [44b592f](https://github.com/gocd/docker-gocd-agent/commit/44b592f) Create home directory `/home/go` for docker agent images based on debian.

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -49,7 +49,19 @@ RUN \
 # unzip the zip file into /go-agent, after stripping the first path prefix
   unzip /tmp/go-agent.zip -d / && \
   mv go-agent-<%= gocd_version %> /go-agent && \
-  rm /tmp/go-agent.zip
+  rm /tmp/go-agent.zip && \
+  # ensure that logs are printed to console output
+<% %w(agent-bootstrapper-log4j.properties agent-launcher-log4j.properties agent-log4j.properties).each do |log_properties_file| -%>
+  sed -i -e 's/\(log4j.rootLogger.*\)/\1, stdout/g' /go-agent/config/<%= log_properties_file %> && \
+  sed -i -e 's/\(log4j.rootCategory.*\)/\1, stdout/g' /go-agent/config/<%= log_properties_file %> && \
+  echo "" >> /go-agent/config/<%= log_properties_file %> && \
+  echo "" >> /go-agent/config/<%= log_properties_file %> && \
+  echo "# Log to stdout" >> /go-agent/config/<%= log_properties_file %> && \
+  echo "log4j.appender.stdout=org.apache.log4j.ConsoleAppender" >> /go-agent/config/<%= log_properties_file %> && \
+  echo "log4j.appender.stdout.layout=org.apache.log4j.PatternLayout" >> /go-agent/config/<%= log_properties_file %> && \
+  echo "log4j.appender.stdout.layout.conversionPattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n" >> /go-agent/config/<%= log_properties_file %> && \
+<% end -%>
+  true
 
 ADD docker-entrypoint.sh /
 


### PR DESCRIPTION
* rootLogger sends log events to console appender that logs to stdout
* do not redirect the output of `server.sh` to a file