### PR TITLE
Remove volume instructions

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -29,8 +29,6 @@ LABEL gocd.version="<%= gocd_version %>" \
 <% add_files.each do |file, meta| -%>
 ADD <%= meta[:url] %> <%= file %>
 <% end %>
-# allow mounting ssh keys, dotfiles, and the go server config and data
-VOLUME /godata
 
 # force encoding
 ENV LANG=en_US.utf8


### PR DESCRIPTION
- When you define volume, there's no way to put anything in that directory
except mounting volume on it. This makes extending this Dockerfile
almost useless.
- Does not prevent users from specifying a volume mount in docker run.