### PR TITLE
Add a healthcheck instruction.

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -59,4 +59,6 @@ COPY <%= log_config_file %> /go-agent/config/<%= log_config_file %>
 
 ADD docker-entrypoint.sh /
 
+HEALTHCHECK --start-period=60s --retries=5 CMD curl 'http://localhost:8152/health/v1/isConnectedToServer'
+
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Will show up something like this -

<img width="1431" alt="screen shot 2017-10-09 at 10 20 37 am" src="https://user-images.githubusercontent.com/4715748/31325684-7a04c0c0-acdd-11e7-8786-01ed1a460ae3.png">


@ketan - let me know if the defaults for the healthcheck is not good enough - https://docs.docker.com/engine/reference/builder/#healthcheck

I will add the healthcheck instruction to the server once https://github.com/gocd/gocd/pull/3912 is merged