### PR TITLE
Remove alpine-3.5 and alpine-3.6 from the rakefile for publishing doc…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,32 +62,6 @@ maybe_credentials = "#{ENV['GIT_USER']}:#{ENV['GIT_PASSWORD']}@" if ENV['GIT_USE
 [
   {
     distro: 'alpine',
-    version: '3.5',
-    add_files: tini_and_gosu_add_file_meta,
-    create_user_and_group: [
-      'addgroup -g ${GID} go',
-      'adduser -D -u ${UID} -s /bin/bash -G go go'
-    ],
-    before_install: [
-      'apk --no-cache upgrade',
-      'apk add --no-cache openjdk8-jre-base git mercurial subversion openssh-client bash curl'
-    ]
-  },
-  {
-      distro: 'alpine',
-      version: '3.6',
-      add_files: tini_and_gosu_add_file_meta,
-      create_user_and_group: [
-          'addgroup -g ${GID} go',
-          'adduser -D -u ${UID} -s /bin/bash -G go go'
-      ],
-      before_install: [
-          'apk --no-cache upgrade',
-          'apk add --no-cache openjdk8-jre-base git mercurial subversion openssh-client bash curl'
-      ]
-  },
-  {
-    distro: 'alpine',
     version: '3.7',
     add_files: tini_and_gosu_add_file_meta,
     create_user_and_group: [


### PR DESCRIPTION
…ker image

* As part of publish-cloud-based-artifacts JobPublish-Docker-Agents JOB the agent published alpine 3.5 and 3.6 agent image and failed due to some network issues.
* remove these entries as of now to fix the build.
* these entries will be added again once the publish pipeline passes.
https://build.gocd.org/go/tab/build/detail/publish-cloud-based-artifacts/17/publish/1/publish-docker-agents

**This is required to push the release**