### PR TITLE
Clean image after push.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ rake gocd-agent-ubuntu-16.04:build_image
 GOCD_VERSION=X.Y.Z GOCD_AGENT_DOWNLOAD_URL=https://download.gocd.io/binaries/X.Y.Z-PPPP/generic/go-agent-X.Y.Z-PPPP.zip
 rake publish [--trace]
 ```
+**_Note:_** *_Image will be removed from machine post push. To disable auto cleanup add env `CLEAN_IMAGES=false`_*
 
 
 # License
 
 ```plain
-Copyright 2017 ThoughtWorks, Inc.
+Copyright 2018 ThoughtWorks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ gocd_version = get_var('GOCD_VERSION')
 download_url = get_var('GOCD_AGENT_DOWNLOAD_URL')
 gocd_full_version = get_var('GOCD_FULL_VERSION')
 gocd_git_sha = get_var('GOCD_GIT_SHA')
+remove_image_post_push = get_var('CLEAN_IMAGES') || true
 
 ROOT_DIR = Dir.pwd
 
@@ -292,6 +293,7 @@ maybe_credentials = "#{ENV['GIT_USER']}:#{ENV['GIT_PASSWORD']}@" if ENV['GIT_USE
       tag = "v#{gocd_full_version}"
       sh("docker tag #{image_name}:#{image_tag} #{org}/#{image_name}:#{tag}")
       sh("docker push #{org}/#{image_name}:#{tag}")
+      sh("docker rmi -f #{org}/#{image_name}:#{tag}") if remove_image_post_push
     end
 
     task :docker_push_image_stable do
@@ -300,6 +302,7 @@ maybe_credentials = "#{ENV['GIT_USER']}:#{ENV['GIT_PASSWORD']}@" if ENV['GIT_USE
       sh("docker pull #{experimental_org}/#{image_name}:v#{gocd_full_version}")
       sh("docker tag #{experimental_org}/#{image_name}:v#{gocd_full_version} #{org}/#{image_name}:#{image_tag}")
       sh("docker push #{org}/#{image_name}:#{image_tag}")
+      sh("docker rmi -f #{org}/#{image_name}:#{tag}") if remove_image_post_push
     end
 
     desc "Publish #{image_name} to dockerhub"


### PR DESCRIPTION
This is to remove the docker image after a push. Use `CLEAN_IMAGES=false` to disable image clean up.