### PR TITLE
Use GOCD_STABLE_RELEASE to determine the s3 bucket to pull the GoCD b

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,8 +45,8 @@ gocd_full_version = versionFile('go_full_version') || get_var('GOCD_FULL_VERSION
 gocd_version = versionFile('go_version') || get_var('GOCD_VERSION')
 gocd_git_sha = versionFile('git_sha') || get_var('GOCD_GIT_SHA')
 remove_image_post_push = ENV['CLEAN_IMAGES'] || true
-
-download_url = ENV['GOCD_AGENT_DOWNLOAD_URL'] || "https://download.gocd.org/experimental/binaries/#{gocd_full_version}/generic/go-agent-#{gocd_full_version}.zip"
+is_stable_release = ENV['GOCD_STABLE_RELEASE'] == "true" || false
+download_url = ENV['GOCD_AGENT_DOWNLOAD_URL'] || "https://download.gocd.org#{is_stable_release ? "/" : "/experimental/" }binaries/#{gocd_full_version}/generic/go-agent-#{gocd_full_version}.zip"
 
 # Perform docker login if token is specified
 Docker.login


### PR DESCRIPTION
Specified a new ENV_VAR `GOCD_STABLE_RELEASE` for `publish-cloud-based-artifacts`  pipeline

Fix for https://github.com/gocd/docker-gocd-agent/issues/78