### PR TITLE
Upgrade git on Centos images

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -249,8 +249,9 @@ agents = [
         add_files: tini_and_gosu_add_file_meta,
         create_user_and_group: create_user_and_group_cmd,
         before_install: [
+            'yum install -y https://centos6.iuscommunity.org/ius-release.rpm',
             'yum update -y',
-            'yum install -y java-1.8.0-openjdk-headless git mercurial subversion openssh-clients bash unzip curl',
+            'yum install -y java-1.8.0-openjdk-headless git2u-core mercurial subversion openssh-clients bash unzip curl',
             'yum clean all'
         ]
     },
@@ -262,8 +263,9 @@ agents = [
         add_files: tini_and_gosu_add_file_meta,
         create_user_and_group: create_user_and_group_cmd,
         before_install: [
+            'yum install -y https://centos7.iuscommunity.org/ius-release.rpm',
             'yum update -y',
-            'yum install -y java-1.8.0-openjdk-headless git mercurial subversion openssh-clients bash unzip curl',
+            'yum install -y java-1.8.0-openjdk-headless git2u-core mercurial subversion openssh-clients bash unzip curl',
             'yum clean all'
         ]
     }


### PR DESCRIPTION
[IUS repos](https://ius.io/) are mentioned on the [official Git download page](https://git-scm.com/download/linux). Without using it, or SCL, it's a pain to install a newer version of git. 

See: https://github.com/gocd/docker-gocd-agent/issues/62

Also, Ubuntu 18.04 based agent image has git 2.17.1.

/cc @varshavaradarajan (was the one who made me do this ...)

Fixes #62.