### PR TITLE
Fix setting locale failed issue

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -31,7 +31,9 @@ ADD <%= meta[:url] %> <%= file %>
 <% end %>
 
 # force encoding
-ENV LANG=en_US.utf8
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
 <% unless ['docker', 'alpine'].include?(distro) -%>
 ENV GO_JAVA_HOME="/go-agent/jre"
 <% end-%>

--- a/Rakefile
+++ b/Rakefile
@@ -170,8 +170,9 @@ agents = [
             'apt-get update',
             # see https://bugs.debian.org/775775
             # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-            'apt-get install -y git subversion mercurial openssh-client bash unzip curl',
-            'apt-get autoclean'
+            'apt-get install -y git subversion mercurial openssh-client bash unzip curl locales',
+            'apt-get autoclean',
+            'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'
         ] + install_java
     },
     {
@@ -183,8 +184,9 @@ agents = [
         create_user_and_group: create_user_and_group_cmd,
         before_install: [
             'apt-get update',
-            'apt-get install -y git subversion mercurial openssh-client bash unzip curl',
-            'apt-get autoclean'
+            'apt-get install -y git subversion mercurial openssh-client bash unzip curl locales',
+            'apt-get autoclean',
+            'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'
         ] + install_java
     },
     {
@@ -196,8 +198,9 @@ agents = [
         create_user_and_group: create_user_and_group_cmd,
         before_install: [
             'apt-get update',
-            'apt-get install -y  git subversion mercurial openssh-client bash unzip curl',
+            'apt-get install -y  git subversion mercurial openssh-client bash unzip curl locales',
             'apt-get autoclean',
+            'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'
         ] + install_java
     },
     {
@@ -209,8 +212,9 @@ agents = [
         create_user_and_group: create_user_and_group_cmd,
         before_install: [
             'apt-get update',
-            'apt-get install -y  git subversion mercurial openssh-client bash unzip curl',
-            'apt-get autoclean'
+            'apt-get install -y  git subversion mercurial openssh-client bash unzip curl locales',
+            'apt-get autoclean',
+            'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'
         ] + install_java
     },
     {
@@ -222,8 +226,9 @@ agents = [
         create_user_and_group: create_user_and_group_cmd,
         before_install: [
             'apt-get update',
-            'apt-get install -y  git subversion mercurial openssh-client bash unzip curl',
-            'apt-get autoclean'
+            'apt-get install -y  git subversion mercurial openssh-client bash unzip curl locales',
+            'apt-get autoclean',
+            'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'
         ] + install_java
     },
     {


### PR DESCRIPTION
I‘ve open a issue https://github.com/gocd/docker-gocd-agent/issues/88

This pull request will set the locale for the go-agent image, 

```
root@3519fd2a5386:/# locale
LANG=en_US.utf8
LANGUAGE=
LC_CTYPE="en_US.utf8"
LC_NUMERIC="en_US.utf8"
LC_TIME="en_US.utf8"
LC_COLLATE="en_US.utf8"
LC_MONETARY="en_US.utf8"
LC_MESSAGES="en_US.utf8"
LC_PAPER="en_US.utf8"
LC_NAME="en_US.utf8"
LC_ADDRESS="en_US.utf8"
LC_TELEPHONE="en_US.utf8"
LC_MEASUREMENT="en_US.utf8"
LC_IDENTIFICATION="en_US.utf8"
LC_ALL=
```

Then the gradle problem `Malformed input or input contains unmappable characters` will be solved.

Also I've verified all the images and found that the `ubuntu` and `debian` have such problem, 

```
gocd/gocd-agent-debian-8:v18.10.0
$ exec locale
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
LANG=en_US.utf8
LANGUAGE=
LC_CTYPE="en_US.utf8"
LC_NUMERIC="en_US.utf8"
LC_TIME="en_US.utf8"
LC_COLLATE="en_US.utf8"
LC_MONETARY="en_US.utf8"
LC_MESSAGES="en_US.utf8"
LC_PAPER="en_US.utf8"
LC_NAME="en_US.utf8"
LC_ADDRESS="en_US.utf8"
LC_TELEPHONE="en_US.utf8"
LC_MEASUREMENT="en_US.utf8"
LC_IDENTIFICATION="en_US.utf8"
LC_ALL=


gocd/gocd-agent-debian-9:v18.10.0
$ exec locale
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
LANG=en_US.utf8
LANGUAGE=
LC_CTYPE="en_US.utf8"
LC_NUMERIC="en_US.utf8"
LC_TIME="en_US.utf8"
LC_COLLATE="en_US.utf8"
LC_MONETARY="en_US.utf8"
LC_MESSAGES="en_US.utf8"
LC_PAPER="en_US.utf8"
LC_NAME="en_US.utf8"
LC_ADDRESS="en_US.utf8"
LC_TELEPHONE="en_US.utf8"
LC_MEASUREMENT="en_US.utf8"
LC_IDENTIFICATION="en_US.utf8"
LC_ALL=


gocd/gocd-agent-ubuntu-14.04:v18.10.0
$ exec locale
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
LANG=en_US.utf8
LANGUAGE=
LC_CTYPE="en_US.utf8"
LC_NUMERIC="en_US.utf8"
LC_TIME="en_US.utf8"
LC_COLLATE="en_US.utf8"
LC_MONETARY="en_US.utf8"
LC_MESSAGES="en_US.utf8"
LC_PAPER="en_US.utf8"
LC_NAME="en_US.utf8"
LC_ADDRESS="en_US.utf8"
LC_TELEPHONE="en_US.utf8"
LC_MEASUREMENT="en_US.utf8"
LC_IDENTIFICATION="en_US.utf8"
LC_ALL=
locale: Cannot set LC_ALL to default locale: No such file or directory

gocd/gocd-agent-ubuntu-16.04:v18.10.0
$ exec locale
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
LANG=en_US.utf8
LANGUAGE=
LC_CTYPE="en_US.utf8"
LC_NUMERIC="en_US.utf8"
LC_TIME="en_US.utf8"
LC_COLLATE="en_US.utf8"
LC_MONETARY="en_US.utf8"
LC_MESSAGES="en_US.utf8"
LC_PAPER="en_US.utf8"
LC_NAME="en_US.utf8"
LC_ADDRESS="en_US.utf8"
LC_TELEPHONE="en_US.utf8"
LC_MEASUREMENT="en_US.utf8"
LC_IDENTIFICATION="en_US.utf8"
LC_ALL=


gocd/gocd-agent-ubuntu-18.04:v18.10.0
$ exec locale
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
LANG=en_US.utf8
LANGUAGE=
LC_CTYPE="en_US.utf8"
LC_NUMERIC="en_US.utf8"
LC_TIME="en_US.utf8"
LC_COLLATE="en_US.utf8"
LC_MONETARY="en_US.utf8"
LC_MESSAGES="en_US.utf8"
LC_PAPER="en_US.utf8"
LC_NAME="en_US.utf8"
LC_ADDRESS="en_US.utf8"
LC_TELEPHONE="en_US.utf8"
LC_MEASUREMENT="en_US.utf8"
LC_IDENTIFICATION="en_US.utf8"
LC_ALL=

```

So I change them as well.

Please help to verify.