### PR TITLE
Include continue_to_build flag to alpine 3.6 image

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,6 +97,7 @@ agents = [
         version: '3.6',
         release_name: '3.6',
         eol_date: '2019-05-01',
+        continue_to_build: 'true',
         add_files: tini_and_gosu_add_file_meta,
         create_user_and_group: [
             'addgroup -g ${GID} go',


### PR DESCRIPTION
Alpine 3.6 also reaching EOL by 2019-05-01. Adding deprecation warning to 19.1 release notes