### PR TITLE
Updating fedora 28 EOL to 2019-06-01

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -263,8 +263,7 @@ agents = [
         distro: 'fedora',
         version: '28',
         release_name: '28',
-        eol_date: '2019-05-01', # approximate date - 1 year from release date, check when the build fails
-        continue_to_build: 'true',
+        eol_date: '2019-06-01', # Fedora has 13 months for EOL
         add_files: tini_and_gosu_add_file_meta,
         create_user_and_group: create_user_and_group_cmd,
         before_install: [


### PR DESCRIPTION
As per Fedora release lifecycle page - https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle - every version has 13 months of support