### PR TITLE
Force install `nss` to get `libnss3.so` onto alpine images to fix broken openjdk8 packages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -113,7 +113,7 @@ agents = [
         ],
         before_install: [
             'apk --no-cache upgrade',
-            'apk add --no-cache openjdk8-jre-base git mercurial subversion openssh-client bash curl'
+            'apk add --no-cache nss openjdk8-jre-base git mercurial subversion openssh-client bash curl'
         ]
     },
     {
@@ -128,7 +128,7 @@ agents = [
         ],
         before_install: [
             'apk --no-cache upgrade',
-            'apk add --no-cache openjdk8-jre-base git mercurial subversion openssh-client bash curl'
+            'apk add --no-cache nss openjdk8-jre-base git mercurial subversion openssh-client bash curl'
         ]
     },
     {
@@ -143,7 +143,7 @@ agents = [
         ],
         before_install: [
             'apk --no-cache upgrade',
-            'apk add --no-cache openjdk8-jre-base git mercurial subversion openssh-client bash curl'
+            'apk add --no-cache nss openjdk8-jre-base git mercurial subversion openssh-client bash curl'
         ]
     },
     {
@@ -158,7 +158,7 @@ agents = [
         ],
         before_install: [
             'apk --no-cache upgrade',
-            'apk add --no-cache openjdk8-jre-base git mercurial subversion openssh-client bash curl'
+            'apk add --no-cache nss openjdk8-jre-base git mercurial subversion openssh-client bash curl'
         ]
     },
     {
@@ -176,7 +176,7 @@ agents = [
         ],
         before_install: [
             'apk --no-cache upgrade',
-            'apk add --no-cache openjdk8-jre-base git mercurial subversion openssh-client bash curl'
+            'apk add --no-cache nss openjdk8-jre-base git mercurial subversion openssh-client bash curl'
         ],
         setup_commands: [
             'sh -c "$(which dind) dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375" > /usr/local/bin/nohup.out 2>&1 &'


### PR DESCRIPTION
The alpine openjdk8 package has removed `nss` from its dependencies, even though it actually needs it, as of `openjdk8-jre-base-8.201.08-r0`. This ought to be fixed in later releases, per https://github.com/docker-library/openjdk/pull/294.